### PR TITLE
chore: update links

### DIFF
--- a/Round-1/README.md
+++ b/Round-1/README.md
@@ -55,7 +55,7 @@
 | 20  |               [Cart](https://github.com/plskz/react-projects)               | [Day 030](day030.md) |
 | 21  |            [Cocktails](https://github.com/plskz/react-projects)             | [Day 031](day031.md) |
 | 22  |       [@Erutidians/auto-dop](https://github.com/Erutidians/auto-dop)        | [day 035](day035.md) |
-| 23  |                        [Plskz.me](https://plskz.me)                         | [day 047](day047.md) |
+| 23  |                        [Plskz.me](https://plskz-me.vercel.app/)                         | [day 047](day047.md) |
 | 23  | [FEM-Getting-Started-CSS](https://github.com/plskx/FEM-Getting-Started-CSS) | [day 059](day059.md) |
 
 [<< Home](../README.md) | [Day 1 >>](day001.md)

--- a/Round-1/README.md
+++ b/Round-1/README.md
@@ -55,7 +55,7 @@
 | 20  |               [Cart](https://github.com/plskz/react-projects)               | [Day 030](day030.md) |
 | 21  |            [Cocktails](https://github.com/plskz/react-projects)             | [Day 031](day031.md) |
 | 22  |       [@Erutidians/auto-dop](https://github.com/Erutidians/auto-dop)        | [day 035](day035.md) |
-| 23  |                        [Plskz.me](https://plskz-me.vercel.app/)                         | [day 047](day047.md) |
+| 23  |                  [Plskz.me](https://plskz-me.vercel.app/)                   | [day 047](day047.md) |
 | 23  | [FEM-Getting-Started-CSS](https://github.com/plskx/FEM-Getting-Started-CSS) | [day 059](day059.md) |
 
 [<< Home](../README.md) | [Day 1 >>](day001.md)

--- a/Round-1/day048.md
+++ b/Round-1/day048.md
@@ -12,7 +12,7 @@
 
 ### Today's Progress:
 
-- deployed to vercel ([plskz.me](https://plskz.me))
+- deployed to vercel ([plskz.me](https://plskz-me.vercel.app/))
 
   ![plskz.me](https://user-images.githubusercontent.com/57343545/180192406-0cfdf9f6-353c-47f6-8413-6535d5f09175.png)
 

--- a/Round-1/day049.md
+++ b/Round-1/day049.md
@@ -13,7 +13,7 @@
 ### Today's Progress:
 
 - continue reading [Player Who Can't Level Up](https://anilist.co/manga/130511/The-Player-Who-Cant-Level-Up/)
-- [plskz.me](https://plskz.me):
+- [plskz.me](https://plskz-me.vercel.app/):
   - feat(socials): add wakatime and anilist
   - feat: add support for mobile
   - chore(meta): update image

--- a/Round-1/day050.md
+++ b/Round-1/day050.md
@@ -13,7 +13,7 @@
 ### Today's Progress:
 
 - finished reading [Player Who Can't Level Up](https://anilist.co/manga/130511/The-Player-Who-Cant-Level-Up/)
-- [plskz.me](https://plskz.me):
+- [plskz.me](https://plskz-me.vercel.app/):
 
   - fix(theme): from user's `default system theme` to `night theme`
   - feat: add discord status (using [lanyard api](https://api.lanyard.rest/v1/users/90431685472038912))


### PR DESCRIPTION
# Description

This PR updates plskz.me to [plskz-me.vercel.app](https://plskz-me.vercel.app/)

> **Note**
> Domain plskz.me expired July 2, 2022 - July 3, 2023